### PR TITLE
Use native JS getter for `shouldHide`

### DIFF
--- a/javascripts/discourse/connectors/discovery-list-area/monday-hide-main-outlet-contents.js
+++ b/javascripts/discourse/connectors/discovery-list-area/monday-hide-main-outlet-contents.js
@@ -1,22 +1,11 @@
-import Component from '@glimmer/component';
-import { withPluginApi } from "discourse/lib/plugin-api"
-import { tracked } from '@glimmer/tracking';
+import Component from "@glimmer/component";
 import { inject as service } from "@ember/service";
 import { defaultHomepage } from "discourse/lib/utilities";
 
 export default class MondayHideMainOutletContents extends Component {
-    @service router;
+  @service router;
 
-    @tracked mustHide = true;
-
-    constructor() {
-        super(...arguments);
-        this.mustHide = (this.router.currentRouteName === `discovery.${defaultHomepage()}`);
-
-        withPluginApi("0.3.0", (api) => {
-            api.onPageChange((url, title) => {
-                this.mustHide = (this.router.currentRouteName === `discovery.${defaultHomepage()}`);
-            });
-        });
-    }
+  get mustHide() {
+    return this.router.currentRouteName === `discovery.${defaultHomepage()}`;
+  }
 }


### PR DESCRIPTION
Using onPageChange can introduce race conditions with other plugins (e.g. the discourse-calendar plugin has an onPageChange hook which looks for a certain DOM element. If the discourse-calendar hook runs before the one in this theme, the DOM element would still be hidden and the calendar would fail to be hidden.

Using a native getter (with Ember's autotracking) means that everything is declarative, and there is less chance of unexpected race conditions. Ultimately this approach means that `mustHide` will be changed at precisely the same time as the Ember route change, instead of waiting a little later for the `onPageChange` event to fire.

Ideally the discourse-calendar plugin should also move towards a declarative approach instead of the `onPageChange` hook. But for the issue we're seeing, changing just this theme is enough to resolve it.